### PR TITLE
Update Halo HAMP dataset and update requirements

### DIFF
--- a/how_to_ac3airborne/_toc.yml
+++ b/how_to_ac3airborne/_toc.yml
@@ -58,10 +58,8 @@ sections:
       title: BACARDI
     - file: datasets/halo/dropsondes
       title: Dropsondes
-    - file: datasets/halo/hamp_radiometer
+    - file: datasets/halo/hamp_unified
       title: HAMP radiometer
-    - file: datasets/halo/hamp_radar
-      title: HAMP radar
     - file: datasets/halo/smart
       title: SMART
 - file: flight_segmentation

--- a/how_to_ac3airborne/datasets/polar/eagle.ipynb
+++ b/how_to_ac3airborne/datasets/polar/eagle.ipynb
@@ -148,7 +148,7 @@
    "metadata": {},
    "source": [
     "### Reading the data\n",
-    "A description on how to work with locally stored or cached data can be found [Caching and local datasets](../../examples/caching_and_local_datasets.html). Assuming the data have been downloaded and stored in */work/mech/data/ac3airborne/*, the arguments for the cache option needs to be defined as follows:"
+    "A description on how to work with locally stored or cached data can be found [Caching and local datasets](caching). Assuming the data have been downloaded and stored in */work/mech/data/ac3airborne/*, the arguments for the cache option needs to be defined as follows:"
    ]
   },
   {

--- a/how_to_ac3airborne/datasets/polar/hawk.ipynb
+++ b/how_to_ac3airborne/datasets/polar/hawk.ipynb
@@ -146,7 +146,7 @@
    "metadata": {},
    "source": [
     "### Reading the data\n",
-    "A description on how to work with locally stored or cached data can be found [Caching and local datasets](../../examples/caching_and_local_datasets.html). Assuming the data have been downloaded and stored in */work/mech/data/ac3airborne/*, the arguments for the cache option needs to be defined as follows:"
+    "A description on how to work with locally stored or cached data can be found [Caching and local datasets](caching). Assuming the data have been downloaded and stored in */work/mech/data/ac3airborne/*, the arguments for the cache option needs to be defined as follows:"
    ]
   },
   {

--- a/how_to_ac3airborne/examples/caching_and_local_datasets.ipynb
+++ b/how_to_ac3airborne/examples/caching_and_local_datasets.ipynb
@@ -5,6 +5,7 @@
    "id": "7209aae8",
    "metadata": {},
    "source": [
+    "(caching)=\n",
     "# Caching and local datasets\n",
     "Datasets accessed via the intake catalog can be either downloaded into a temporary folder, from where they will be deleted after restarting python, or permanently into a specified directory. If the dataset is already contained within the specified directory, intake will load the data from the local source, instead of downloading it again from the remote server. This is recommended for large datasets or datasets which are used regularily.\n",
     "\n",

--- a/how_to_ac3airborne/running_locally.md
+++ b/how_to_ac3airborne/running_locally.md
@@ -7,8 +7,9 @@ In any case, it will involve the following steps:
 * install all required dependencies
 * run the code
 
-You can decide between the [quick an dirty](#quick-and-dirty) method and the method [using `git`](#via-git), which will also set you up to contribute to the book.
+You can decide between the [](#quick-and-dirty) method and the method [using `git`](#via-git), which will also set you up to contribute to the book.
 
+(quick-and-dirty)=
 ## Quick and dirty
 If you just like to run the code of a single notebook and don't care to much about the details, the quickest option might be to download the chapter you are viewing as an ipython notebook (`.ipynb`) via the download button (<i class="fas fa-download"></i>) on the top right of the page. If you don't see the `.ipynb` option here, that's because the source of the page can not be interpreted as a notebook and thus is not available for direct execution.
 
@@ -30,7 +31,7 @@ Afterwards, you can start a local notebook server (either `jupyter notebook` or 
 ```{note}
 Handling requirements in this project is not entirely straightforward, as the requirements strongly depend on which datasets are used. We use [intake catalogs](https://intake.readthedocs.io) to describe how a dataset can be accessed which simplifies a lot of things. But as a consequence the set of required libraries is not only determined by the code in this repository, but also by the entries in the catalog.
 ```
-
+(via-git)=
 ## Via git
 
 If you like to do it more properly, you can also clone the repository via git. Depending on if you have SSH public key authentication set up or not, you can do this via SSH or HTTPS:
@@ -85,6 +86,7 @@ It is installed through the `requirements.txt` and should register itself with `
 If that does not work, please have a look at the [installation instructions](https://jupytext.readthedocs.io/en/latest/install.html) of `jupytext`.
 ```
 
+(interactive)=
 ### Interactive
 `jupyter` itself is not installed by the requirements file. If you're using `pip` you might want to install it as well:
 
@@ -110,6 +112,7 @@ jupyter lab
 :::
 ::::
 
+(compile-the-book)=
 ### Compile the book
 You can also execute `jupyter-book` directly via:
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,6 @@ aiohttp==3.7.4.post0
 ipyleaflet==0.13.6
 simplification>=0.5.14
 ghp-import==1.1.0
+ac3airborne @ git+https://github.com/igmk/ac3airborne@6c99052
+python-dotenv>=1.0.1
 # sphinxcontrib-bibtex==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-jupyter-book==0.10.1 # New toc structure
-jupytext==1.10.3
-matplotlib==3.3.4
-numpy==1.21.5
+jupyter-book>=0.10.1 # New toc structure
+jupytext>=1.10.3
+matplotlib>=3.3.4
+numpy>=1.21.5
 xarray==0.19.0
 intake[dataframe]==0.6.0 # since intake 0.6.1 to_dask() doesn't work anymore without the [dataframe] specification due to a missing msgpack dependency
 intake-xarray==0.4.1
@@ -9,6 +9,6 @@ h5netcdf==0.7.1
 fsspec==0.8.7
 aiohttp==3.7.4.post0
 ipyleaflet==0.13.6
-simplification==0.5.14
+simplification>=0.5.14
 ghp-import==1.1.0
 # sphinxcontrib-bibtex==2.2.0


### PR DESCRIPTION
I noticed the HALO HAMP dataset is now shown in the unified version and thus the two preliminary notebooks are gone. However, the toc still needs to reflect that update. 

I also updated the requirementsfile because the current pinned versions threw errors and wouldn't let me build the book.

Due to the update of jupyter-book I needed to update some cross references.

Things to fix still for windows:

- [ ] the new version of intake seems to cause some errors when trying to read from a csv file via the catalog


I tested on Windows and Linux.

Best Johannes