### PR TITLE
Update Halo Hamp dataset

### DIFF
--- a/how_to_ac3airborne/_toc.yml
+++ b/how_to_ac3airborne/_toc.yml
@@ -58,10 +58,8 @@ sections:
       title: BACARDI
     - file: datasets/halo/dropsondes
       title: Dropsondes
-    - file: datasets/halo/hamp_radiometer
+    - file: datasets/halo/hamp_unified
       title: HAMP radiometer
-    - file: datasets/halo/hamp_radar
-      title: HAMP radar
     - file: datasets/halo/smart
       title: SMART
 - file: flight_segmentation


### PR DESCRIPTION
The HAMP dataset is now available as a unified dataset. The notebooks have been adapted already. However, the table of contents does not reflect this change. This commit fixes this.